### PR TITLE
Changed date conversion to use DGI date conversion template

### DIFF
--- a/islandora_transforms/UCLA_MODS_to_solr.xslt
+++ b/islandora_transforms/UCLA_MODS_to_solr.xslt
@@ -188,10 +188,21 @@
   </xsl:template>  
    
   <xsl:template match="mods:originInfo[mods:dateCreated[@encoding='iso8601']]" mode="CollectingLA">
-    <xsl:variable name="dateStart"
-      select="java:edu.ucla.library.IsoToSolrDateConverter.getStartDateFromIsoDateString(normalize-space(mods:dateCreated[@encoding='iso8601']))" />
-    <xsl:variable name="dateEnd"
-      select="java:edu.ucla.library.IsoToSolrDateConverter.getEndDateFromIsoDateString(normalize-space(mods:dateCreated[@encoding='iso8601']))" />
+    <xsl:variable name="rawText" select="normalize-space(mods:dateCreated[@encoding='iso8601'])"/>
+    <xsl:variable name="dateStart">
+      <xsl:call-template name="get_ISO8601_date">
+        <xsl:with-param name="date" select="$rawText"/>
+        <xsl:with-param name="pid"/>
+        <xsl:with-param name="datastream"/>
+      </xsl:call-template>
+    </xsl:variable>
+    <xsl:variable name="dateEnd">
+      <xsl:call-template name="get_ISO8601_date">
+        <xsl:with-param name="date" select="$rawText"/>
+        <xsl:with-param name="pid"/>
+        <xsl:with-param name="datastream"/>
+      </xsl:call-template>
+    </xsl:variable>
     <field name="mods_dateCreated_dt">
       <xsl:value-of select="$dateStart"/>
     </field>


### PR DESCRIPTION
When using [the following namespaces](https://github.com/BrandonMorr/basic-solr-config/blob/7b627eedfe2496ee3067b4f470c090e51e6206c0/islandora_transforms/UCLA_MODS_to_solr.xslt#L33-L35), if a mods:dateCreated encoding="iso8601" is found in the mods record we perform date conversion.

It's unknown why the previous solution stopped working, but switching over to DGI's custom ISO8601 conversion template solves the issue.

This should be heavily tested as to not create any regressions.